### PR TITLE
Correct typo in documentation

### DIFF
--- a/lib/Crixa.pm
+++ b/lib/Crixa.pm
@@ -111,7 +111,7 @@ __END__
     use Crixa;
 
     my $mq       = Crixa->connect( host => 'localhost' );
-    my $channel  = $mq->channel;
+    my $channel  = $mq->new_channel;
     my $exchange = $channel->exchange( name => 'hello' );
 
     $exchange->publish('Hello World');


### PR DESCRIPTION
The Crixa object only supports `new_channel`, not `channel`.
